### PR TITLE
Speed Curve Update

### DIFF
--- a/arc_overhangs_v1.0.0.py
+++ b/arc_overhangs_v1.0.0.py
@@ -506,7 +506,7 @@ def main(gCodeFileStream, path2GCode) -> None:
                                     break
                     if "G1 F" in line.split(";", 1)[0]:  # Special block-speed-command
                         curPrintSpeed: str = line
-                        curPrintSpeedVal = int(curPrintSpeed[4:])
+                        curPrintSpeedVal = float(curPrintSpeed[4:])
                     if layer.exportThisLine(idline - 1):  # Subtract 1 because there's a disconnect between line IDs here and line IDs when calculating which lines to delete (TODO fix)
                         close, distance_to_arc = layer.dist2Bridging(line, parameters.get("CoolingSettingDetectionDistance", 3))
                         if close:  # Ensure we have a valid point and arcs exist

--- a/arc_overhangs_v1.0.0.py
+++ b/arc_overhangs_v1.0.0.py
@@ -132,8 +132,8 @@ def makeFullSettingDict(gCodeSettingDict: dict) -> dict:
         "HilbertFillingPercentage": 100,  # Infill percentage of the massive layers with special cooling.
         "HilbertInfillExtrusionMultiplier": 1.05, # Multiplies how much filament will be extruded while printing Hilbert curves.
         "HilbertTravelEveryNSeconds": 6,  # When N seconds are driven, it will continue printing somewhere else (very rough approx).
-        "MinArea": 0,  # Minimum overhang area to generate arcs. Unit: mm²
-        "MinBridgeLength": 0,  # Minimum bridge length to generate arcs. Unit: mm
+        "MinArea": 5,  # Minimum overhang area to generate arcs. Unit: mm²
+        "MinBridgeLength": 5,  # Minimum bridge length to generate arcs. Unit: mm
         "MinDistanceFromPerimeter": 1 * gCodeSettingDict.get("extrusion_width"),  # Control how much bumpiness you allow between arcs and perimeter. Lower will follow perimeter better, but create a lot of very small arcs. Should be more than 1 Arc width! Unit: mm
         "MinStartArcs": 2,  # How many arcs shall be generated in the first step
         "Path2Output": r"",  # Leave empty to overwrite the file or write to a new file. Full path required.
@@ -1225,7 +1225,7 @@ class Layer():
         if not p:
             return False, maxDetectionDistance  # Skip if no point is extracted
         distances = self.indexedOldPolys.query_nearest(p, max_distance=maxDetectionDistance, return_distance=True)[1]
-        if distances:
+        if distances.size > 0:
             distance = min(distances) # Return all distances to polygons that may be in the detection distance
             if distance < maxDetectionDistance:
                 return True, distance # Return shortest distance within the threshold
@@ -1467,7 +1467,7 @@ def get_farthest_points(from_geom: Geometry, to_poly: Polygon, number_of_points:
 
     bisector_vectors = []
     for id in top_indices:
-        p0, p1, p2 = coords[id], coords[id-1], coords[id+1]
+        p0, p1, p2 = coords[id], coords[id-1], coords[(id+1)%len(coords)]
         v_a = np.array([p1.x - p0.x, p1.y - p0.y])
         v_b = np.array([p2.x - p0.x, p2.y - p0.y])
         bisector_vectors.append(get_angle_bisector(v_a, v_b))

--- a/arc_overhangs_v1.0.0.py
+++ b/arc_overhangs_v1.0.0.py
@@ -1206,9 +1206,11 @@ class Layer():
         p = getPtfromCmd(line)
         if not p:
             return False, maxDetectionDistance  # Skip if no point is extracted
-        distance = min(self.indexedOldPolys.query_nearest(p, max_distance=maxDetectionDistance, return_distance=True)[1]) # Return all distances to polygons that may be in the detection distance
-        if distance < maxDetectionDistance:
-            return True, distance # Return shortest distance within the threshold
+        distances = self.indexedOldPolys.query_nearest(p, max_distance=maxDetectionDistance, return_distance=True)[1]
+        if distances:
+            distance = min(distances) # Return all distances to polygons that may be in the detection distance
+            if distance < maxDetectionDistance:
+                return True, distance # Return shortest distance within the threshold
         return False, maxDetectionDistance
 
     def spotFanSetting(self, lastfansetting: float) -> float:

--- a/arc_overhangs_v1.0.0.py
+++ b/arc_overhangs_v1.0.0.py
@@ -62,6 +62,7 @@ from math import (
     degrees,
     radians
 )
+from numpy.typing import NDArray
 from shapely import (
     Geometry,
     GeometryCollection,
@@ -70,8 +71,10 @@ from shapely import (
     Polygon,
     LineString,
     MultiLineString,
+    covered_by,
     covers,
     difference,
+    get_coordinates,
     points,
     prepare,
     destroy_prepared,
@@ -360,7 +363,6 @@ def main(gCodeFileStream, path2GCode) -> None:
                         warnings.warn("Skipping Polygon because no StartLine Found")
                         layer.failedArcGenPolys.append(poly)
                         continue
-                    prepare(startLineString)
                     prepare(boundaryWithOutStartLine)
                     startpt = getStartPtOnLS(startLineString, parameters)
 
@@ -388,7 +390,6 @@ def main(gCodeFileStream, path2GCode) -> None:
                                 warnings.warn("Initialization Error: no concentric Arc could be generated at startpoints, moving on")
                                 layer.failedArcGenPolys.append(poly)
                                 continue
-                    destroy_prepared(startLineString)
                     destroy_prepared(boundaryWithOutStartLine)
                     arcBoundaries = getArcBoundaries(concentricArcs)
                     finalarcs.append(concentricArcs[-1])
@@ -797,13 +798,30 @@ class Layer():
                 poly = makePolygonFromGCode(linesWithStart)  # Create polygon from collected lines
                 if poly:
                     self.extPerimeterPolys.append(poly)  # Add polygon to the list
+                    prepare(poly)
                 extPerimeterIsStarted = False
+        holesToRemove = []
+        for poly1 in self.extPerimeterPolys:
+            for poly2 in self.extPerimeterPolys:
+                if poly1==poly2 or poly1 in holesToRemove or poly2 in holesToRemove:
+                    continue
+                if covers(poly1, poly2):
+                    poly1 = difference(poly1, poly2)
+                    holesToRemove.append(poly2)
+                elif covered_by(poly1, poly2):
+                    poly2 = difference(poly2, poly1)
+                    holesToRemove.append(poly1)
+        for hole in holesToRemove:
+            try:
+                self.extPerimeterPolys.remove(hole)
+            except ValueError:
+                print("Polygon does not exist.")
 
     def makeStartLineString(self, poly: Polygon, kwargs: dict = {}):
         """Create a starting LineString for arc generation by intersecting with previous layer's external perimeter."""
         if not self.extPerimeterPolys:
             self.makeExternalPerimeter2Polys()  # Generate external perimeter polygons if not available
-        
+
         if len(self.extPerimeterPolys) < 1:
             warnings.warn(f"Layer {self.layernumber}: No ExternalPerimeterPolys found in prev Layer")
             return None, None
@@ -1303,12 +1321,15 @@ def fill_remaining_space(last_arc: Arc, r_min: float, r_max: float, min_distance
     text = "Recursion not needed to fill space."
     for id in range(parameters.get("SafetyBreak_MaxArcNumber")):
         remaining_space = difference(poly, buffer(filled_space, parameters.get("ArcWidth") / 2))  # Calculate remaining space
-        farthest_points, longest_distances = get_farthest_points(filled_space.boundary, poly, allowedRetries + 1)  # Find the farthest point
+        farthest_points, longest_distances, bisectors = get_farthest_points(filled_space.boundary, poly, allowedRetries + 1)  # Find the farthest point
 
         if farthest_points.size == 0 or longest_distances[failureCount] < min_distance_from_perimeter:
             break  # Stop if no valid point or distance is too small
-
-        start_pt = move_toward_point(farthest_points[failureCount], last_arc.center, parameters.get("ArcCenterOffset", 2))  # Adjust start point
+        
+        # Move in the direction of the angle bisector defined by the furthest point and its neighbors
+        # (i.e. Move toward the previous arc's center by traveling along the opposite direction of the arc's "normal")
+        start_pt = Point(farthest_points[failureCount].x + parameters.get("ArcCenterOffset", 2) * bisectors[failureCount][0],
+                         farthest_points[failureCount].y + parameters.get("ArcCenterOffset", 2) * bisectors[failureCount][1])
         concentric_arcs = generateMultipleConcentricArcs(start_pt, r_min, r_max, poly.boundary, remaining_space, parameters)  # Generate arcs
 
         if len(concentric_arcs) == 0:
@@ -1318,8 +1339,7 @@ def fill_remaining_space(last_arc: Arc, r_min: float, r_max: float, min_distance
             continue
         
         failureCount = 0
-        last_arc = concentric_arcs[-1]  # Update the last arc
-        filled_space = intersection(poly, unary_union((filled_space, Polygon(last_arc.circle))))  # Merge filled space with new arcs
+        filled_space = intersection(poly, unary_union((filled_space, Polygon(concentric_arcs[-1].circle))))  # Merge filled space with new arcs
         arcs.extend(concentric_arcs)  # Add new arcs to the list
         
         text = f"Filling remaining space. Iterations: {id}. Arcs this iteration: {len(concentric_arcs)}."
@@ -1412,7 +1432,7 @@ def create_circle_between_angles(center:Point, radius:float, startAngle:float, e
     points = np.column_stack((radius * np.sin(theta) + x, radius * np.cos(theta) + y))  # Compute circle points
     return LineString(points)
 
-def get_farthest_points(from_geom: Geometry, to_poly: Polygon, number_of_points: int = 1) -> tuple:
+def get_farthest_points(from_geom: Geometry, to_poly: Polygon, number_of_points: int = 1) -> Tuple[NDArray, NDArray, NDArray]:
     """
     Find the point on a given geometry that is farthest away from the boundary of a polygon.
     
@@ -1432,33 +1452,37 @@ def get_farthest_points(from_geom: Geometry, to_poly: Polygon, number_of_points:
     """
     if from_geom.is_empty:
         return None, None  # Return None if the input geometry is empty
-    
-    prepare(to_poly.boundary)  # Prepare the polygon boundary for faster distance calculations
 
-    try:
-        coords = points(from_geom.coords)  # Extract points from the geometry's coordinates
-    except NotImplementedError:
-        # Handle MultiLineString by extracting coordinates from each part
-        if isinstance(from_geom, MultiLineString):
-            coords = []
-            for geom in from_geom.geoms:
-                coords.extend(geom.coords)
-            coords = points(coords)
+    coords = points(get_coordinates(from_geom))  # Extract points from the geometry's coordinates
 
     distances = distance(to_poly.boundary, coords)  # Calculate distances from each point to the polygon's boundary
     farthest_points = []
     longest_distances = []
-    # Get indices sorted by descending distances
-    sorted_indices = np.argsort(distances)[::-1]
-
-    # Select top 'number_of_points' indices
-    top_indices = sorted_indices[:number_of_points]
+    # Get the top indices sorted by descending distances
+    top_indices = np.argsort(distances, kind='heapsort')[:-(number_of_points + 1):-1]
 
     # Retrieve the longest distances and farthest points
     longest_distances = distances[top_indices]
     farthest_points = coords[top_indices]
+
+    bisector_vectors = []
+    for id in top_indices:
+        p0, p1, p2 = coords[id], coords[id-1], coords[id+1]
+        v_a = np.array([p1.x - p0.x, p1.y - p0.y])
+        v_b = np.array([p2.x - p0.x, p2.y - p0.y])
+        bisector_vectors.append(get_angle_bisector(v_a, v_b))
     
-    return farthest_points, longest_distances
+    return farthest_points, longest_distances, bisector_vectors
+
+def get_angle_bisector(vec_a, vec_b):
+    """Calculates the normalized angle bisector."""
+
+    unit_a = vec_a / np.linalg.norm(vec_a)
+    unit_b = vec_b / np.linalg.norm(vec_b)
+
+    bisector_direction = unit_a + unit_b
+
+    return bisector_direction / np.linalg.norm(bisector_direction)
 
 def move_toward_point(start_point: Point, target_point: Point, distance: float, angle_correction: float = 0.0) -> Point:
     """Move a point by a set distance toward another point and adjust the angle direction"""
@@ -1495,22 +1519,6 @@ def move_toward_point(start_point: Point, target_point: Point, distance: float, 
     
     # Return the new point
     return Point(new_x, new_y)
-
-# def redistribute_vertices(geom: LineString, dist: float) -> LineString:  # TODO: consider shapely's segmentize(geometry, max_segment_length, ...)
-#     """Redistribute vertices of a LineString or MultiLineString at a specified distance."""
-#     if geom.geom_type == 'LineString':
-#         num_vert = ceil(geom.length / dist)  # Calculate number of vertices
-#         if num_vert == 0:
-#             num_vert = 1  # Ensure at least one vertex
-#         return LineString(
-#             [geom.interpolate(float(n) / num_vert, normalized=True)  # Interpolate vertices
-#              for n in range(num_vert + 1)])
-#     elif geom.geom_type == 'MultiLineString':
-#         parts = [redistribute_vertices(part, dist) for part in geom.geoms]  # Recursively process each part
-#         return type(geom)([p for p in parts if not p.is_empty])  # Filter out empty parts
-#     else:
-#         warnings.warn('unhandled geometry %s', (geom.geom_type,))  # Warn for unsupported geometry types
-#         return geom
 
 def generateMultipleConcentricArcs(startpt: Point, rMin: float, rMax: float, basePoly: Polygon, remainingSpace: Polygon, kwargs={}) -> list:
     """Generate concentric arcs within a given range of the radius and boundary."""
@@ -1658,7 +1666,7 @@ def readSettingsFromGCode2dict(gcodeLines: list, fallbackValuesDict: dict) -> di
 
 def compute_print_speed(distance, min_speed, max_speed, max_distance):
     """
-    Interpolates between min_speed and max_speed based on distance.
+    Interpolates quadratically between min_speed and max_speed based on distance.
     - distance: the measured distance from the arc boundary.
     - min_speed: the speed to use when distance is 0 or very close.
     - max_speed: the normal print speed (when distance >= max_distance).
@@ -1667,7 +1675,7 @@ def compute_print_speed(distance, min_speed, max_speed, max_distance):
     if distance >= max_distance:
         return max_speed
     else:
-        return min_speed + (max_speed - min_speed) * (distance / float(max_distance))
+        return min_speed + (max_speed - min_speed) * (distance*distance / float(max_distance*max_distance))
 
 def checkforNecesarrySettings(gCodeSettingDict: dict) -> bool:
     """Check if necessary slicer settings are enabled for the script to work."""

--- a/arc_overhangs_v1.0.0.py
+++ b/arc_overhangs_v1.0.0.py
@@ -46,10 +46,11 @@ KNOWN ISSUES:
 """
 
 #!/usr/bin/python
+from itertools import chain
 import sys
 import argparse
 import re
-from typing import Any, List
+from typing import Any, List, Tuple
 from math import (
     log2,
     ceil,
@@ -113,6 +114,8 @@ def makeFullSettingDict(gCodeSettingDict: dict) -> dict:
         "ArcFanSpeed": 255,  # Cooling to full blast = 255
         "ArcMinPrintSpeed": 0.5 * 60,  # Unit: mm/min
         "ArcPrintSpeed": 1.5 * 60,  # Unit: mm/min
+        "UseCustomArcTemp": False, # Set to True to use a custom arc printing temperature
+        "CustomArcTemp": 200, # The temperature (in °C) to wait for before printing arcs
         "ArcSlowDownBelowThisDuration": 3,  # Arc Time below this Duration => slow down, Unit: sec
         "ArcPointsPerMillimeter": 10,  # Higher will slow down the code but give better support for following arcs. Recommended values: >=10 when "UseLeastAmountOfCenterPoints": False; else, value can be as low as 1.
         "ArcTravelFeedRate": 30 * 60,  # Slower travel speed, Unit: mm/min
@@ -217,6 +220,7 @@ _SLICER_SETTINGS_MAP = {
         "retract_length": "retract_length",
         'retract_speed': 'retract_speed',
         "solid_infill_extrusion_width": "solid_infill_extrusion_width",
+        'temperature': 'temperature',
         'travel_speed': 'travel_speed',
         'use_relative_e_distances': 'use_relative_e_distances',
     },
@@ -236,6 +240,7 @@ _SLICER_SETTINGS_MAP = {
         "retraction_length": "retract_length",
         'retraction_speed': 'retract_speed',
         "internal_solid_infill_line_width": "solid_infill_extrusion_width",
+        'nozzle_temperature': 'temperature',
         'travel_speed': 'travel_speed',
         'use_relative_e_distances': 'use_relative_e_distances',
     },
@@ -403,7 +408,7 @@ def main(gCodeFileStream, path2GCode) -> None:
                     # Poly finished
                     remain2FillPercent = (1 - finalFilledSpace.area / poly.area) * 100
                     if remain2FillPercent > 100 - parameters.get("WarnBelowThisFillingPercentage"):
-                        # layer.failedArcGenPolys.append(poly) # Bugged percentage detection, not reliable TODO
+                        # layer.failedArcGenPolys.append(poly) # Percentage detection not reliable TODO
                         warnings.warn(f"layer {idl}: The Overhang Area is only {100 - remain2FillPercent:.0f}% filled with Arcs. Please try again with adapted Parameters: set 'ExtendArcsIntoPerimeter' higher to enlarge small areas. Lower the MaxDistanceFromPerimeter to follow the curvature more precise. Set 'ArcCenterOffset' to 0 to reach delicate areas.")
                         # plot_geometry(poly)
                         # plot_geometry(finalFilledSpace, color='b', kwargs={"filled"})
@@ -449,6 +454,7 @@ def main(gCodeFileStream, path2GCode) -> None:
                 isInjected = False
                 hilbertIsInjected = False
                 curPrintSpeed = "G1 F600"
+                curPrintSpeedVal = 600
                 messedWithSpeed = False
                 messedWithFan = False
                 if gcodeWasModified:
@@ -463,6 +469,9 @@ def main(gCodeFileStream, path2GCode) -> None:
                         if ";TYPE" in line and not isInjected:  # Inject arcs at the very start
                             injectionStart = idline
                             modifiedlayer.lines.append(";TYPE:Arc infill\n")
+                            if parameters.get("UseCustomArcTemp", False):
+                                # Wait for the custom temperature before beginning arcs.
+                                modifiedlayer.lines.append(f"M109 S{parameters.get('CustomArcTemp')} ; Wait for custom arc temp\n")
                             modifiedlayer.lines.append(f"M106 S{parameters.get('ArcFanSpeed')}\n")
                             for overhangline in arcOverhangGCode:
                                 for arcline in overhangline:
@@ -476,6 +485,9 @@ def main(gCodeFileStream, path2GCode) -> None:
                                     modifiedlayer.lines.append(line2TravelMove(layer.lines[id], parameters, ignoreZ=True))  # Travel
                                     modifiedlayer.lines.append(retractGCode(retract=False, kwargs=parameters))  # Extrude
                                     break
+                            if parameters.get("UseCustomArcTemp", False):
+                                # Restore the normal temperature after arcs are printed.
+                                modifiedlayer.lines.append(f"M109 S{parameters.get(getSlicerSpecificName("temperature"))} ; Restore normal temperature\n")
                     if layer.oldpolys and parameters.get("doSpecialCooling"):
                         if getSlicerSpecificName(";TYPE:Solid infill") in line and not hilbertIsInjected:  # Startpoint of solid infill: print all hilberts from here.
                             hilbertIsInjected = True
@@ -492,13 +504,25 @@ def main(gCodeFileStream, path2GCode) -> None:
                                     modifiedlayer.lines.append(retractGCode(retract=False, kwargs=parameters))  # Extrude
                                     break
                     if "G1 F" in line.split(";", 1)[0]:  # Special block-speed-command
-                        curPrintSpeed = line
-                    if layer.exportThisLine(idline - 1):  # Subtract 1 because there's a disconnect between line IDs here and line IDs when calculating which lines to delete. Should fix TODO
-                        if layer.isClose2Bridging(line, parameters.get("CoolingSettingDetectionDistance")):
+                        curPrintSpeed: str = line
+                        curPrintSpeedVal = int(curPrintSpeed[4:])
+                    if layer.exportThisLine(idline - 1):  # Subtract 1 because there's a disconnect between line IDs here and line IDs when calculating which lines to delete (TODO fix)
+                        close, distance_to_arc = layer.dist2Bridging(line, parameters.get("CoolingSettingDetectionDistance", 3))
+                        if close:  # Ensure we have a valid point and arcs exist
+                            # Determine new print speed based on distance
+                            new_speed = compute_print_speed(
+                                distance_to_arc,
+                                parameters.get("aboveArcsPerimeterPrintSpeed"),  # Slowest speed near arcs
+                                curPrintSpeedVal,  # Normal speed
+                                parameters.get("CoolingSettingDetectionDistance", 3)  # Max distance for speedup
+                            )
+
                             if not messedWithFan:
                                 modifiedlayer.lines.append(f"M106 S{parameters.get('aboveArcsFanSpeed')}\n")
                                 messedWithFan = True
-                            modline = line.strip("\n") + f" F{parameters.get('aboveArcsPerimeterPrintSpeed')}\n"
+
+                            # Modify line to include adjusted speed
+                            modline = line.strip("\n") + f" F{new_speed:.2f} ; Near arc speed: {100*(new_speed / float(curPrintSpeedVal)):.1f}%\n"
                             modifiedlayer.lines.append(modline)
                             messedWithSpeed = True
                         else:
@@ -506,7 +530,7 @@ def main(gCodeFileStream, path2GCode) -> None:
                                 modifiedlayer.lines.append(f"M106 S{layer.fansetting:.0f}\n")
                                 messedWithFan = False
                             if messedWithSpeed:
-                                modifiedlayer.lines.append(curPrintSpeed + "\n")
+                                modifiedlayer.lines.append(curPrintSpeed)
                                 messedWithSpeed = False
                             modifiedlayer.lines.append(line)
                 if messedWithFan:
@@ -1042,7 +1066,7 @@ class Layer():
                             verified = True
                             break
                     for intersectId in overIntersectors:
-                        if intersects(poly, prevIndexedOverhangPerimeters.geometries[intersectId]):  # Check if this poly intersects an overhang
+                        if intersects(poly, prevIndexedOverhangPerimeters.geometries[intersectId]) and not covers(prevIndexedOverhangPerimeters.geometries[intersectId], poly):  # Check if this poly hangs over an overhang
                             verified = True
                             break
                 if verified:
@@ -1175,15 +1199,17 @@ class Layer():
         
         return compositeList
 
-    def isClose2Bridging(self, line: str, maxDetectionDistance: float = 3) -> bool:
-        """Check if a G-code line is close to a bridging area."""
+    def dist2Bridging(self, line: str, maxDetectionDistance: float = 3) -> Tuple[bool, float]:
+        """Check a G-code line's distance to a bridging area."""
         if not "G1" in line:
-            return False  # Skip non-G1 lines
+            return False, maxDetectionDistance  # Skip non-G1 lines
         p = getPtfromCmd(line)
         if not p:
-            return False  # Skip if no point is extracted
-        distances = self.indexedOldPolys.query_nearest(p, max_distance=maxDetectionDistance, return_distance=True)[1] # Return all distances to polygons that may be in the detection distance
-        return any(dist <= maxDetectionDistance for dist in distances) # Return True if any distance is within the threshold
+            return False, maxDetectionDistance  # Skip if no point is extracted
+        distance = min(self.indexedOldPolys.query_nearest(p, max_distance=maxDetectionDistance, return_distance=True)[1]) # Return all distances to polygons that may be in the detection distance
+        if distance < maxDetectionDistance:
+            return True, distance # Return shortest distance within the threshold
+        return False, maxDetectionDistance
 
     def spotFanSetting(self, lastfansetting: float) -> float:
         """Find and return the fan setting (M106) from the G-code lines."""
@@ -1627,6 +1653,19 @@ def readSettingsFromGCode2dict(gcodeLines: list, fallbackValuesDict: dict) -> di
         gCodeSettingDict["perimeter_extrusion_width"] = gCodeSettingDict.get("nozzle_diameter", 0.4) * (float(gCodeSettingDict.get("perimeter_extrusion_width").strip("%")) / 100)
 
     return gCodeSettingDict
+
+def compute_print_speed(distance, min_speed, max_speed, max_distance):
+    """
+    Interpolates between min_speed and max_speed based on distance.
+    - distance: the measured distance from the arc boundary.
+    - min_speed: the speed to use when distance is 0 or very close.
+    - max_speed: the normal print speed (when distance >= max_distance).
+    - max_distance: the distance at which normal speed is reached.
+    """
+    if distance >= max_distance:
+        return max_speed
+    else:
+        return min_speed + (max_speed - min_speed) * (distance / float(max_distance))
 
 def checkforNecesarrySettings(gCodeSettingDict: dict) -> bool:
     """Check if necessary slicer settings are enabled for the script to work."""


### PR DESCRIPTION
## Additions
- GCODE now will get faster as it gets further from arcs (as opposed to remaining a constant slowed speed until the arcs were sufficiently far. The slowdown distance is controlled via the `"CoolingSettingDetectionDistance"` parameter. [Blog post](https://github.com/Wasupmacuz/arc-overhang-prusaslicer-integration/discussions/14#discussioncomment-12569884)

> [!WARNING]
> The feature above has not been tested and may lead to increased warping.
- You can now set a custom temperature for arcs! Many users had temperature included in their finely tuned slicer settings and lowering the temperature could compromise the quality of the print. By setting `"UseCustomArcTemp"` to `True` (`False` by default), you can then set the arc temperature with `"CustomArcTemp"`.
## Changes
- `isClose2Bridging` has been renamed to `dist2Bridging` and functions the same except it now returns the distance that it was calculating anyway.
- Includes a change to collision detection that I thought was already added.